### PR TITLE
ポップアップをデバイスごとにサイズ変させる

### DIFF
--- a/apps/web/app/map/small-program-page.jsx
+++ b/apps/web/app/map/small-program-page.jsx
@@ -9,9 +9,14 @@ const handleContentClick = (event) => {
   event.stopPropagation()
 }
 
-export default function ProgramPopup({ title, url, images, area, place, text }) {
+export default function ProgramPopup({ title, url, images, area, place, text, popheight, popwidth }) {
+  if (!popheight) {
+    popheight = window.innerHeight - 144
+  }
+  if (!popwidth) {
+    popwidth = widthAdjust(window.innerWidth - 24)
+  }
   const [isDisplayPage, setDisplayPage] = useState(false)
-
   function handleclick() {
     setDisplayPage(!isDisplayPage)
   }
@@ -24,7 +29,7 @@ export default function ProgramPopup({ title, url, images, area, place, text }) 
       {
         isDisplayPage && createPortal(
           <div className={styles.backdrop} onClick={handleclick}>
-            <div className={styles.main} onClick={handleContentClick}>
+            <div className={styles.main} onClick={handleContentClick} style={{ width: popwidth, height: popheight }}>
               <label className={styles.popupCloseButton}>
                 <button type="button" onClick={handleclick} />
                 ✕
@@ -47,4 +52,14 @@ export default function ProgramPopup({ title, url, images, area, place, text }) 
       }
     </div>
   )
+}
+
+/**
+ * レスポンシブな幅を提供 (お好みに合わせて値をいじってください)
+ * @param {Number} width
+ * @returns {Number} 調整された幅
+ */
+
+function widthAdjust(width) {
+  return Math.min(width * 0.85, width * 0.5 + 200)
 }

--- a/apps/web/app/map/small-program-page.module.css
+++ b/apps/web/app/map/small-program-page.module.css
@@ -3,7 +3,7 @@
 }
 .popupOpenButton {
     display: block;
-    margin-top: 0.25rem;
+    margin-top: 1rem;
     border: 3px solid hsl(220, 100%, 70%);
     color: hsl(220, 100%, 70%);
     border-radius: 7px;
@@ -25,8 +25,6 @@
     left: 0;
     bottom: 0;
     margin: auto;
-    width: 60vw;
-    height: 80vh;
     background-color: #fcfcfc;
     z-index: 25000;
 }
@@ -53,7 +51,7 @@
     color: #3d3d46;
 }
 .content h1 {
-    color: hsl(220, 100%, 70%);
+    color: #213a54;
     font-size: 2rem;
 }
 .area {

--- a/apps/web/app/map/ysfmap.jsx
+++ b/apps/web/app/map/ysfmap.jsx
@@ -128,11 +128,3 @@ export default function Ysfmap({ picheight, picwidth }) {
 function widthAdjust(width) {
   return Math.min(width, width * 0.6 + 200)
 }
-
-/*
-const [isDisplayPage, setDisplayPage] = useState(false)
-
-  function handleclick() {
-    setDisplayPage(!isDisplayPage)
-  }
-*/


### PR DESCRIPTION
地図でも使っているwidthAdjustを若干式を変えてポップアップにも適用させました。
PCで横幅*0.5+200、スマホで横幅*0.85と画面サイズより少し小さめに。スマホサイズについては適宜調整します。
あと、ポップアップの企画タイトルの色を企画ページに合わせました。