### PR TITLE
buttonのコンポーネントを任意のものを受け入れるようにする

### DIFF
--- a/packages/ganoine/package.json
+++ b/packages/ganoine/package.json
@@ -22,6 +22,7 @@
     "build": "rslib build",
     "dev": "npm run genCss && rslib build --watch",
     "lint": "eslint .",
+    "tsc": "tsc --noEmit",
     "genCss": "hcm -o generated/hcm src/**/*.module.css --localsConvention camelCaseOnly --watch"
   },
   "devDependencies": {

--- a/packages/ganoine/src/button.module.css
+++ b/packages/ganoine/src/button.module.css
@@ -8,6 +8,7 @@
     border-width: 4px;
     border-style: solid;
     border-radius: var(--semantic-radius-medium);
+    text-decoration: none;
 }
 
 .ganoine-button > * {
@@ -33,6 +34,6 @@
     border-color: var(--semantic-button-dangor-fill);
 }
 
-.ganoine-button[data-disabled] {
+.ganoine-button[data-disabled="true"] {
     opacity: 0.33;
 }

--- a/packages/ganoine/src/button.story.tsx
+++ b/packages/ganoine/src/button.story.tsx
@@ -1,6 +1,7 @@
 import { Button } from './button'
 import './extra/base.css'
 import type { Meta, StoryObj } from '@storybook/react'
+import { Button as AriaButton } from 'react-aria-components'
 
 export default {
   title: 'Ganoine/Button',
@@ -10,6 +11,7 @@ export default {
 export const Default = {
   args: {
     children: <p>デフォルトの表示です</p>,
+    onPress: () => alert('ボタンが押されました'),
   },
 } as StoryObj<typeof Button>
 
@@ -17,6 +19,17 @@ export const Primary = {
   args: {
     children: <p>デフォルトの表示です</p>,
     kind: 'primary',
+    component: AriaButton,
+    onPress: () => alert('ボタンが押されました'),
+  },
+} as StoryObj<typeof Button>
+
+export const PrimaryAsLink = {
+  args: {
+    children: <p>デフォルトの表示です</p>,
+    kind: 'primary',
+    component: 'a',
+    href: 'https://example.com',
   },
 } as StoryObj<typeof Button>
 
@@ -24,6 +37,8 @@ export const Danger = {
   args: {
     children: <p>デフォルトの表示です</p>,
     kind: 'danger',
+    component: AriaButton,
+    onPress: () => alert('ボタンが押されました'),
   },
 } as StoryObj<typeof Button>
 

--- a/packages/ganoine/src/button.tsx
+++ b/packages/ganoine/src/button.tsx
@@ -1,20 +1,35 @@
 'use client'
 
-import type { ComponentPropsWithRef, ReactNode } from 'react'
+import type { ComponentPropsWithRef, ReactNode, ElementType } from 'react'
 import { Button as AriaButton, ButtonProps as AriaButtonProperties } from 'react-aria-components'
 import styles from './button.module.css'
 
 export type ButtonKinds = 'primary' | 'danger'
 
-export type ButtonProperties = {
+export type ButtonProperties<T extends ElementType = typeof AriaButton> = {
   children: ReactNode
   disabled?: boolean
   kind?: ButtonKinds
-} & Omit<ComponentPropsWithRef<'button'>, 'children'> & Omit<AriaButtonProperties, 'children'>
+  component?: T
+} & Omit<ComponentPropsWithRef<T>, 'children'> & Omit<AriaButtonProperties, 'children'>
 
-export function Button(properties: ButtonProperties): ReactNode {
+/**
+ * ## Ganoineのボタンコンポーネント
+ * `component`プロパティを指定することで、任意のコンポーネントをボタンとして使用できます。
+ *
+ * 例えば、`component="a"`とすることで、リンクとしてのボタンを作成できます。
+ * デフォルトでは、`react-aria-components`の`Button`コンポーネントが使用されます。
+ *
+ * `kind`プロパティを指定することで、ボタンの種類を変更できます。
+ *
+ * `primary`は主に使用するボタン、`danger`は危険な操作を行うボタンとして使用されます。
+ *
+ * `disabled`プロパティを指定することで、ボタンを無効化できます。
+ **/
+export function Button<T extends ElementType = typeof AriaButton>(properties: ButtonProperties<T>): ReactNode {
+  const Component = (properties.component || AriaButton) as ElementType
   return (
-    <AriaButton
+    <Component
       {...properties}
       ref={properties.ref}
       className={styles.ganoineButton}
@@ -22,6 +37,6 @@ export function Button(properties: ButtonProperties): ReactNode {
       data-kind={properties.kind}
     >
       {properties.children}
-    </AriaButton>
+    </Component>
   )
 }


### PR DESCRIPTION
- ボタン(React Aria の Button、標準のbuttonタグ)やリンク(aタグ、Linkタグ)などです
- 引数はそのコンポーネントのタグに準じます
  - デフォルトは`react-aria-components`の`Button`が使用されます