### PR TITLE
サイトフッター周りの調整 (完)

### DIFF
--- a/apps/web/app/compoent/global/bottom-menu.jsx
+++ b/apps/web/app/compoent/global/bottom-menu.jsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import styles from './navi-footer.module.css'
+import styles from './bottom-menu.module.css'
 import Link from 'next/link'
 import { MdHome, MdOutlineFastfood, MdWysiwyg, MdAccessTime, MdOutlineMap } from 'react-icons/md'
 import { usePathname } from 'next/navigation'
 
-export default function NaviFooter() {
+export default function BottomMenu() {
   /*
     activePathの初期化・更新について:
     pathname = "/a/b/c" とすると、
@@ -34,10 +34,10 @@ export default function NaviFooter() {
     { label: '地図', href: '/map', Icon: MdOutlineMap },
   ]
   return (
-    <footer className={styles['nvft']}>
-      <div className={styles['nvft-blur']} />
-      <nav className={styles['nvft-main']}>
-        <ul className={styles['nvft-list']}>
+    <footer className={styles['btmenu-base']}>
+      <div className={styles['btmenu-blur']} />
+      <nav className={styles['btmenu-main']}>
+        <ul className={styles['btmenu-list']}>
           {items.map(({ label, href, Icon }) => {
             const isActive = href === activePage
             return (
@@ -45,10 +45,10 @@ export default function NaviFooter() {
                 <Link
                   href={href}
                   // onClick={() => setActivePage(href)}
-                  className={`${styles['nvft-item']} ${isActive ? styles['nvft-item-active'] : styles['nvft-item-normal']}`}
+                  className={`${styles['btmenu-item']} ${isActive ? styles['btmenu-item-active'] : styles['btmenu-item-normal']}`}
                 >
-                  <Icon size={40} className={styles['nvft-icon']} />
-                  <span className={styles['nvft-label']}>
+                  <Icon size={40} className={styles['btmenu-icon']} />
+                  <span className={styles['btmenu-label']}>
                     {' '}
                     {label}
                     {' '}

--- a/apps/web/app/compoent/global/bottom-menu.module.css
+++ b/apps/web/app/compoent/global/bottom-menu.module.css
@@ -1,68 +1,68 @@
-.nvft {
+.btmenu-base {
   z-index: 9999; /* 最前面の意 */
   position: fixed; /* 他の要素に位置が全く影響されない */
   bottom: 0; /* 下の余白ゼロ */
-  height: 64px;
+  height: var(--bottom-menu-height);
   width: 100vw;
 }
 
-.nvft-blur {
-  position: absolute; /* nvft基準 */
+.btmenu-blur {
+  position: absolute; /* btmenu基準 */
   background-color: hsla(0, 0%, 100%, 0.85);
   backdrop-filter: blur(5px);
   height: 100%;
   width: 100%;
 }
 @media (prefers-color-scheme: dark) {
-  .nvft-blur {
+  .btmenu-blur {
     background-color: hsla(0, 0%, 0%, 0.85);
   }
 }
 
-.nvft-main {
-  position: absolute; /* nvft基準 */
+.btmenu-main {
+  position: absolute; /* btmenu基準 */
   width: 100%;
 }
 
-.nvft-list {
+.btmenu-list {
   display: flex; /* 横に並べる */
   justify-content: space-around; /* 余白が |1 2 2 2 2 1| */
   list-style: none; /* ・をなくす */
   width: 100%;
 }
 
-.nvft-item {
+.btmenu-item {
   position: relative;
   display: flex;
   justify-content: center;
-  width: 64px;
-  height: 64px;
+  width: var(--bottom-menu-height);
+  height: var(--bottom-menu-height);
   border-radius: 4px;
   text-decoration: none; /* <a>タグは標準で underline してしまうので */
 }
-.nvft-item-active {
+.btmenu-item-active {
   background-color: #42507B;
   color: var(--background);
 }
-.nvft-item-normal {
+.btmenu-item-normal {
   /* backgroundなし */
   color: var(--foreground);
 }
 @media (prefers-color-scheme: dark) {
-  .nvft-item-active {
+  .btmenu-item-active {
     background-color: var(--foreground);
   }
 }
 
-.nvft-icon {
-  position: absolute; /* nvft-item基準 */
+.btmenu-icon {
+  position: absolute; /* btmenu-item基準 */
   top: 0;
   color: inherit;
   background-color: inherit;
 }
 
-.nvft-label {
-  position: absolute; /* nvft-item基準 */
+.btmenu-label {
+  position: absolute; /* btmenu-item基準 */
   bottom: 0;
   font-size: 14px;
   line-height: 24px; /* 実質height */

--- a/apps/web/app/compoent/global/site-footer.jsx
+++ b/apps/web/app/compoent/global/site-footer.jsx
@@ -1,17 +1,15 @@
 'use client'
 
 import Image from 'next/image'
-import { isMobile } from 'react-device-detect'
 import styles from './site-footer.module.css'
+import './site-footer.rwd.css'
 import { solveBasePath } from '@/app/lib/index.js'
 
 export default function SiteFooter() {
-  const height = isMobile ? 192 : 128
-  const padding = isMobile ? 64 : 0
   return (
-    <footer className={styles['ft-base']} style={{ height: height }}>
-      <div className={styles['ft-bg']} />
-      <div className={styles['ft-main']} style={{ height: height, paddingBottom: padding }}>
+    <footer className={`${styles['ft-base']} ft-rwd-height`}>
+      <div className={`${styles['ft-bg']} ft-rwd-height`} />
+      <div className={`${styles['ft-main']} ft-main-rwd-padding-bottom ft-rwd-height`}>
         <Image
           src={solveBasePath('/latimeria_logo_768.png')}
           alt="シーラカンスのロゴです"

--- a/apps/web/app/compoent/global/site-footer.module.css
+++ b/apps/web/app/compoent/global/site-footer.module.css
@@ -1,6 +1,6 @@
 .ft-base {
-  position: sticky; /* 通常の要素と同様 */
-  bottom:0;
+  position: absolute; /* content-base基準 */
+  bottom: 0;
   width: 100%;
   margin-top: 16px;
 }
@@ -8,7 +8,6 @@
 .ft-bg {
   position: absolute; /* ft-base基準 */
   width: 100%;
-  height: 100%;
   background-color: #213060;
 }
 

--- a/apps/web/app/compoent/global/site-footer.rwd.css
+++ b/apps/web/app/compoent/global/site-footer.rwd.css
@@ -1,0 +1,11 @@
+.ft-rwd-height {
+  height: var(--site-footer-height);
+}
+
+body.isMobile .ft-rwd-height {
+  height: calc(var(--site-footer-height) + var(--bottom-menu-height));
+}
+
+body.isMobile .ft-main-rwd-padding-bottom {
+  padding-bottom: var(--bottom-menu-height);
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,8 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --bottom-menu-height: 64px;
+  --site-footer-height: 128px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -38,6 +40,12 @@ body {
 
 #content-base {
   min-height: 100vh;
+  position: relative;
+  padding-bottom: var(--site-footer-height);
+}
+
+body.isMobile #content-base {
+  padding-bottom: calc(var(--site-footer-height) + var(--bottom-menu-height));
 }
 
 /*統一するスタイルの定義

--- a/apps/web/app/menu.jsx
+++ b/apps/web/app/menu.jsx
@@ -2,7 +2,7 @@
 
 import { isMobile } from 'react-device-detect'
 import Header from '@/app/compoent/header'
-import NaviFooter from '@/app/compoent/global/navi-footer'
+import BottomMenu from '@/app/compoent/global/bottom-menu'
 import { ClientProvider } from '@/app/provider.jsx'
 import { useEffect, useState } from 'react'
 
@@ -15,9 +15,11 @@ export default function Menu() {
 
   if (!mounted) return
 
+  document.body.classList.toggle('isMobile', isMobile)
+
   return (
     <ClientProvider>
-      {isMobile ? <NaviFooter /> : <Header /> }
+      {isMobile ? <BottomMenu /> : <Header /> }
     </ClientProvider>
   )
 }


### PR DESCRIPTION
`menu.jsx`で **`useEffect`を用いて** PCとスマホで異なるメニューを表示するようにしました。
その際、`useEffect`が発動したタイミングで
```document.body.classList.toggle('isMobile', isMobile)```
をします。つまり直接 `import rwdcssfilename.css` したcssに
```
body.isMobile .rwdclassname {
  rwd-something: value;
}
```
とすることでスマホとPCでの表示を分けることが出来ます。