### PR TITLE
Add clickable css

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -126,5 +126,5 @@ a:not(:has(*)) {
 
 .clickable {
   /** 装飾のデザインにかかわる類は一切記述しない */
-  cursor: default;
+  cursor: pointer;
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -123,3 +123,7 @@ a:not(:has(*)) {
   /** hsl(220, 100%, 70%); */
   border-radius: 2rem;
 }
+
+.clickable {
+  cursor: default;
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -125,5 +125,6 @@ a:not(:has(*)) {
 }
 
 .clickable {
+  /** 装飾のデザインにかかわる類は一切記述しない */
   cursor: default;
 }


### PR DESCRIPTION
クリックできるのにわかりづらいところが所々にあり、いちいちcssを記述するのもめんどくさいだろうなってことでglobal.cssに追加しました
コメントにある通り、必ずすべてに共通する要素だけを記述するために、色や大きさ等の類はここに記述しない方針で行きます