### PR TITLE
eslintが`apps/web`で動かないのを修正

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict = true
+public-hoist-pattern[]=*eslint*


### PR DESCRIPTION
弊環境(Webstorm)ではこの変更によって正しく動作しました。おそらくVSCodeも同様だと思います。    
もしこれを反映させてもエラーが出る場合は再度`pnpm i`を行って下さい